### PR TITLE
ECL: refact(Repository) Move out clinicaltrial builder from repositor…

### DIFF
--- a/src/clinical-trial/gateways/file-repository/clinical-trial-factory.test.ts
+++ b/src/clinical-trial/gateways/file-repository/clinical-trial-factory.test.ts
@@ -1,0 +1,175 @@
+import { ClinicalTrialFactory } from './clinical-trial-factory'
+import { ClinicalTrial } from '../../application/entities/ClinicalTrial'
+import { Contact } from '../../application/entities/Contact'
+import { ContactDetails } from '../../application/entities/ContactDetails'
+import { Recruitment } from '../../application/entities/Recruitment'
+import { StudyType } from '../../application/entities/StudyType'
+import { TherapeuticArea } from '../../application/entities/TherapeuticArea'
+import { Title } from '../../application/entities/Title'
+import { Gender } from '../../application/Gender'
+import { PrimaryAge } from '../../application/PrimaryAge'
+import { RecruitmentStatus } from '../../application/RecruitmentStatus'
+import { SecondaryAge } from '../../application/SecondaryAge'
+import { ClinicalTrialModel } from '../model/ClinicalTrialModel'
+import { ContactDetailsModel } from '../model/ContactDetailsModel'
+import { ContactModel } from '../model/ContactModel'
+import { RecruitmentModel } from '../model/RecruitmentModel'
+import { StudyTypeModel } from '../model/StudyTypeModel'
+import { TherapeuticAreaModel } from '../model/TherapeuticAreaModel'
+import { TitleModel } from '../model/TitleModel'
+
+describe('clinical trial factory', () => {
+  it('should build a clinical trial', () => {
+    // GIVEN
+    const clinicalTrialModel = new ClinicalTrialModel(
+      '123',
+      'NCT51265816',
+      {
+        AFR_number: 'AFRXXXXXXXX',
+        national_number: '2011-006209-83',
+      },
+      new TitleModel(
+        'AGADIR',
+        'Circuler l’ADN pour améliorer le résultat de l’oncologie Patient. Une étude randomisée'
+      ),
+      new TitleModel(
+        'AGADIR',
+        'le meme titre mais en scientifique'
+      ),
+      new RecruitmentModel(
+        'RECRUITING',
+        ['MALE'],
+        ['IN_UTERO', 'SIXTY_FIVE_PLUS_YEARS'],
+        ['PRETERM_NEWBORN', 'EIGHTY_FIVE_PLUS_YEARS'],
+        400
+      ),
+      new StudyTypeModel(
+        'Human Pharmacology (Phase I)- First administration to humans',
+        'Cum bromium mori, omnes nixuses captis noster, teres mortemes.',
+        'Cur compater cadunt?'
+      ),
+      new Date().toString(),
+      new ContactModel(
+        new ContactDetailsModel(
+          'Institut Bergognié',
+          'Antoine',
+          'Italiano',
+          '5 avenue de l’opera',
+          'bordeaux',
+          'France',
+          '33076',
+          '01 23 45 67 89 ',
+          'aitaliona@example',
+          'Ministère de la santé',
+          '552 178 639 00132'
+        ),
+        new ContactDetailsModel(
+          'John Doe',
+          'John',
+          'Doe',
+          '123 rue de la cabosse',
+          'Saint-François-sur-Seine',
+          'France',
+          '01234',
+          '(+33)1 23 45 67 89',
+          'johndoe@example.com',
+          'Ministère de la Santé',
+          '751 610 908 00012'
+        )
+      ),
+      'Cancer des poumons',
+      ['10060929', '10072818'],
+      [new TherapeuticAreaModel('Circulatory and Respiratory Physiological Phenomena', 'G')],
+      new ContactDetailsModel(
+        'Urbss ridetis!',
+        'Flavum uria recte experientias byssus est.',
+        'Pol.',
+        '123 You have to lure, and absorb silence by your flying.',
+        'Ubi est talis contencio?',
+        'Domesticus, primus lamias hic desiderium de dexter, germanus mensa.',
+        '01234',
+        '(+33)5 89 65 47 12',
+        'johndoe@example.com',
+        'Ministère de la Santé',
+        '751 610 908 00012'
+      )
+    )
+
+    // WHEN
+    const clinicalTrial = ClinicalTrialFactory.buildClinicalTrial(clinicalTrialModel)
+
+    // THEN
+    expect(clinicalTrial).toStrictEqual(new ClinicalTrial(
+      'NCT51265816',
+      {
+        AFR_number: 'AFRXXXXXXXX',
+        national_number: '2011-006209-83',
+      },
+      new Title(
+        'AGADIR',
+        'Circuler l’ADN pour améliorer le résultat de l’oncologie Patient. Une étude randomisée'
+      ),
+      new Title(
+        'AGADIR',
+        'le meme titre mais en scientifique'
+      ),
+      new Recruitment(
+        RecruitmentStatus.RECRUITING,
+        [Gender.MALE],
+        [PrimaryAge.IN_UTERO, PrimaryAge.SIXTY_FIVE_PLUS_YEARS],
+        [SecondaryAge.PRETERM_NEWBORN, SecondaryAge.EIGHTY_FIVE_PLUS_YEARS],
+        400
+      ),
+      new StudyType(
+        'Human Pharmacology (Phase I)- First administration to humans',
+        'Cum bromium mori, omnes nixuses captis noster, teres mortemes.',
+        'Cur compater cadunt?'
+      ),
+      new Date().toString(),
+      new Contact(
+        new ContactDetails(
+          'Institut Bergognié',
+          'Antoine',
+          'Italiano',
+          '5 avenue de l’opera',
+          'bordeaux',
+          'France',
+          '33076',
+          '01 23 45 67 89 ',
+          'aitaliona@example',
+          'Ministère de la santé',
+          '552 178 639 00132'
+        ),
+        new ContactDetails(
+          'John Doe',
+          'John',
+          'Doe',
+          '123 rue de la cabosse',
+          'Saint-François-sur-Seine',
+          'France',
+          '01234',
+          '(+33)1 23 45 67 89',
+          'johndoe@example.com',
+          'Ministère de la Santé',
+          '751 610 908 00012'
+        )
+      ),
+      'Cancer des poumons',
+      ['10060929', '10072818'],
+      [new TherapeuticArea('Circulatory and Respiratory Physiological Phenomena', 'G')],
+      new ContactDetails(
+        'Urbss ridetis!',
+        'Flavum uria recte experientias byssus est.',
+        'Pol.',
+        '123 You have to lure, and absorb silence by your flying.',
+        'Ubi est talis contencio?',
+        'Domesticus, primus lamias hic desiderium de dexter, germanus mensa.',
+        '01234',
+        '(+33)5 89 65 47 12',
+        'johndoe@example.com',
+        'Ministère de la Santé',
+        '751 610 908 00012'
+      )
+    ))
+  })
+})

--- a/src/clinical-trial/gateways/file-repository/clinical-trial-factory.test.ts
+++ b/src/clinical-trial/gateways/file-repository/clinical-trial-factory.test.ts
@@ -19,7 +19,7 @@ import { TherapeuticAreaModel } from '../model/TherapeuticAreaModel'
 import { TitleModel } from '../model/TitleModel'
 
 describe('clinical trial factory', () => {
-  it('should build a clinical trial', () => {
+  it('should have a clinical trial', () => {
     // GIVEN
     const clinicalTrialModel = new ClinicalTrialModel(
       '123',
@@ -96,7 +96,7 @@ describe('clinical trial factory', () => {
     )
 
     // WHEN
-    const clinicalTrial = ClinicalTrialFactory.buildClinicalTrial(clinicalTrialModel)
+    const clinicalTrial = ClinicalTrialFactory.create(clinicalTrialModel)
 
     // THEN
     expect(clinicalTrial).toStrictEqual(new ClinicalTrial(

--- a/src/clinical-trial/gateways/file-repository/clinical-trial-factory.ts
+++ b/src/clinical-trial/gateways/file-repository/clinical-trial-factory.ts
@@ -1,0 +1,85 @@
+import { ClinicalTrial } from '../../application/entities/ClinicalTrial'
+import { Contact } from '../../application/entities/Contact'
+import { ContactDetails } from '../../application/entities/ContactDetails'
+import { Recruitment } from '../../application/entities/Recruitment'
+import { StudyType } from '../../application/entities/StudyType'
+import { TherapeuticArea } from '../../application/entities/TherapeuticArea'
+import { Title } from '../../application/entities/Title'
+import { Gender } from '../../application/Gender'
+import { PrimaryAge } from '../../application/PrimaryAge'
+import { SecondaryAge } from '../../application/SecondaryAge'
+import { ClinicalTrialModel } from '../model/ClinicalTrialModel'
+
+export class ClinicalTrialFactory {
+  static buildClinicalTrial(clinicalTrialModel: ClinicalTrialModel): ClinicalTrial {
+    return new ClinicalTrial(
+      clinicalTrialModel.universal_trial_number,
+      clinicalTrialModel.secondaries_trial_numbers,
+      new Title(
+        clinicalTrialModel.public_title.acronym,
+        clinicalTrialModel.public_title.value
+      ),
+      new Title(
+        clinicalTrialModel.scientific_title.acronym,
+        clinicalTrialModel.scientific_title.value
+      ),
+      new Recruitment(
+        clinicalTrialModel.recruitment.status,
+        clinicalTrialModel.recruitment.genders.map((gender: string): Gender => Gender[gender as keyof typeof Gender]),
+        clinicalTrialModel.recruitment.ages_range.map((age: string): PrimaryAge => PrimaryAge[age as keyof typeof PrimaryAge]),
+        clinicalTrialModel.recruitment.ages_range_secondary_identifiers.map((age: string): SecondaryAge => SecondaryAge[age as keyof typeof SecondaryAge]),
+        clinicalTrialModel.recruitment.target_number
+      ),
+      new StudyType(
+        clinicalTrialModel.study_type.phase,
+        clinicalTrialModel.study_type.study_type,
+        clinicalTrialModel.study_type.study_design
+      ),
+      clinicalTrialModel.last_revision_date,
+      new Contact(
+        new ContactDetails(
+          clinicalTrialModel.contact.public_queries.name,
+          clinicalTrialModel.contact.public_queries.firstname,
+          clinicalTrialModel.contact.public_queries.lastname,
+          clinicalTrialModel.contact.public_queries.address,
+          clinicalTrialModel.contact.public_queries.city,
+          clinicalTrialModel.contact.public_queries.country,
+          clinicalTrialModel.contact.public_queries.zip,
+          clinicalTrialModel.contact.public_queries.telephone,
+          clinicalTrialModel.contact.public_queries.email,
+          clinicalTrialModel.contact.public_queries.organization,
+          clinicalTrialModel.contact.public_queries.siret
+        ),
+        new ContactDetails(
+          clinicalTrialModel.contact.scientific_queries.name,
+          clinicalTrialModel.contact.scientific_queries.firstname,
+          clinicalTrialModel.contact.scientific_queries.lastname,
+          clinicalTrialModel.contact.scientific_queries.address,
+          clinicalTrialModel.contact.scientific_queries.city,
+          clinicalTrialModel.contact.scientific_queries.country,
+          clinicalTrialModel.contact.scientific_queries.zip,
+          clinicalTrialModel.contact.scientific_queries.telephone,
+          clinicalTrialModel.contact.scientific_queries.email,
+          clinicalTrialModel.contact.scientific_queries.organization,
+          clinicalTrialModel.contact.scientific_queries.siret
+        )
+      ),
+      clinicalTrialModel.medical_condition,
+      clinicalTrialModel.medical_condition_meddra,
+      clinicalTrialModel.therapeutic_areas.map((item) => new TherapeuticArea(item.value, item.code)),
+      new ContactDetails(
+        clinicalTrialModel.primary_sponsor.name,
+        clinicalTrialModel.primary_sponsor.firstname,
+        clinicalTrialModel.primary_sponsor.lastname,
+        clinicalTrialModel.primary_sponsor.address,
+        clinicalTrialModel.primary_sponsor.city,
+        clinicalTrialModel.primary_sponsor.country,
+        clinicalTrialModel.primary_sponsor.zip,
+        clinicalTrialModel.primary_sponsor.telephone,
+        clinicalTrialModel.primary_sponsor.email,
+        clinicalTrialModel.primary_sponsor.organization,
+        clinicalTrialModel.primary_sponsor.siret
+      )
+    )
+  }
+}

--- a/src/clinical-trial/gateways/file-repository/clinical-trial-factory.ts
+++ b/src/clinical-trial/gateways/file-repository/clinical-trial-factory.ts
@@ -11,7 +11,7 @@ import { SecondaryAge } from '../../application/SecondaryAge'
 import { ClinicalTrialModel } from '../model/ClinicalTrialModel'
 
 export class ClinicalTrialFactory {
-  static buildClinicalTrial(clinicalTrialModel: ClinicalTrialModel): ClinicalTrial {
+  static create(clinicalTrialModel: ClinicalTrialModel): ClinicalTrial {
     return new ClinicalTrial(
       clinicalTrialModel.universal_trial_number,
       clinicalTrialModel.secondaries_trial_numbers,

--- a/src/clinical-trial/gateways/file-repository/clinical-trial-file.repository.test.ts
+++ b/src/clinical-trial/gateways/file-repository/clinical-trial-file.repository.test.ts
@@ -15,7 +15,7 @@ import { ClinicalTrialModel } from '../model/ClinicalTrialModel'
 describe('clinical trial file repository', () => {
   it('should retrieve one clinical trial', async () => {
     // GIVEN
-    const clinicalTrialFileModel = {
+    const clinicalTrialFile = {
       contact: {
         public_queries: {
           address: '',
@@ -76,7 +76,7 @@ describe('clinical trial file repository', () => {
       uuid: '1',
     }
 
-    const repository = await createRepository([clinicalTrialFileModel as ClinicalTrialModel])
+    const repository = await createRepository([clinicalTrialFile as ClinicalTrialModel])
 
     // WHEN
     const clinicalTrial = repository.findOne('1')

--- a/src/clinical-trial/gateways/file-repository/clinical-trial-file.repository.test.ts
+++ b/src/clinical-trial/gateways/file-repository/clinical-trial-file.repository.test.ts
@@ -8,185 +8,106 @@ import { Contact } from '../../application/entities/Contact'
 import { ContactDetails } from '../../application/entities/ContactDetails'
 import { Recruitment } from '../../application/entities/Recruitment'
 import { StudyType } from '../../application/entities/StudyType'
-import { TherapeuticArea } from '../../application/entities/TherapeuticArea'
 import { Title } from '../../application/entities/Title'
-import { Gender } from '../../application/Gender'
-import { PrimaryAge } from '../../application/PrimaryAge'
 import { RecruitmentStatus } from '../../application/RecruitmentStatus'
-import { SecondaryAge } from '../../application/SecondaryAge'
 import { ClinicalTrialModel } from '../model/ClinicalTrialModel'
-import { ContactDetailsModel } from '../model/ContactDetailsModel'
-import { ContactModel } from '../model/ContactModel'
-import { RecruitmentModel } from '../model/RecruitmentModel'
-import { StudyTypeModel } from '../model/StudyTypeModel'
-import { TherapeuticAreaModel } from '../model/TherapeuticAreaModel'
-import { TitleModel } from '../model/TitleModel'
 
 describe('clinical trial file repository', () => {
   it('should retrieve one clinical trial', async () => {
     // GIVEN
-    const publicTitleModel = new TitleModel(
-      'AGADIR',
-      'Circuler l’ADN pour améliorer le résultat de l’oncologie Patient. Une étude randomisée'
-    )
-    const scientificTitleModel = new TitleModel(
-      'AGADIR',
-      'le meme titre mais en scientifique'
-    )
-    const recruitmentModel = new RecruitmentModel(
-      'RECRUITING',
-      ['MALE'],
-      ['IN_UTERO', 'SIXTY_FIVE_PLUS_YEARS'],
-      ['PRETERM_NEWBORN', 'EIGHTY_FIVE_PLUS_YEARS'],
-      400
-    )
-    const studyTypeModel = new StudyTypeModel(
-      'Human Pharmacology (Phase I)- First administration to humans',
-      '',
-      ''
-    )
-    const lastRevisionDateModel = new Date().toString()
-    const universalTrialNumberModel = 'NCT51265816'
-    const secondariesTrialNumbersModel = {
-      AFR_number:  'AFRXXXXXXXX',
-      national_number: '2011-006209-83',
+    const clinicalTrialFileModel = {
+      contact: {
+        public_queries: {
+          address: '',
+          city: '',
+          country: '',
+          email: '',
+          firstname: '',
+          lastname: '',
+          name: '',
+          organization: '',
+          siret: '',
+          telephone: '',
+          zip: '',
+        },
+        scientific_queries: {
+          address: '',
+          city: '',
+          country: '',
+          email: '',
+          firstname: '',
+          lastname: '',
+          name: '',
+          organization: '',
+          siret: '',
+          telephone: '',
+          zip: '',
+        },
+      },
+      last_revision_date: '',
+      medical_condition: '',
+      medical_condition_meddra: [],
+      primary_sponsor: {
+        address: '',
+        city: '',
+        country: '',
+        email: '',
+        firstname: '',
+        lastname: '',
+        name: '',
+        organization: '',
+        siret: '',
+        telephone: '',
+        zip: '',
+      },
+      public_title: { acronym: '', value: '' },
+      recruitment: {
+        ages_range: [],
+        ages_range_secondary_identifiers: [],
+        genders: [],
+        status: 'UNAVAILABLE',
+        target_number: 0,
+      },
+      scientific_title: { acronym: '', value: '' },
+      secondaries_trial_numbers: {},
+      study_type: { phase: '', study_design: '', study_type: '' },
+      therapeutic_areas: [],
+      universal_trial_number: '',
+      uuid: '1',
     }
-    const medicalCondition = 'Cancer des poumons'
-    const medicalConditionMedDRA = ['10060929', '10072818']
-    const therapeuticAreas = [new TherapeuticAreaModel('Circulatory and Respiratory Physiological Phenomena', 'G')]
-    const contactModel = new ContactModel(
-      new ContactDetailsModel(
-        'Institut Bergognié',
-        'Antoine',
-        'Italiano',
-        '5 avenue de l’opera',
-        'bordeaux',
-        'France',
-        '33076',
-        '01 23 45 67 89 ',
-        'aitaliona@example',
-        'Ministère de la santé',
-        '552 178 639 00132'
-      ),
-      new ContactDetailsModel(
-        'John Doe',
-        'John',
-        'Doe',
-        '123 rue de la cabosse',
-        'Saint-François-sur-Seine',
-        'France',
-        '01234',
-        '(+33)1 23 45 67 89',
-        'johndoe@ministere.com',
-        'Ministère de la Santé',
-        ''
-      )
-    )
-    const primarySponsorModel = new ContactDetailsModel(
-      'Institut Bergognié',
-      'Antoine',
-      'Italiano',
-      '5 avenue de l’opera',
-      'bordeaux',
-      'France',
-      '33076',
-      '01 23 45 67 89 ',
-      'aitaliona@example',
-      'Ministère de la santé',
-      '552 178 639 00132'
-    )
 
-    const clinicalTrialModel = ClinicalTrialModelTestingFactory.create({
-      contact: contactModel,
-      last_revision_date: lastRevisionDateModel,
-      medical_condition: medicalCondition,
-      medical_condition_meddra: medicalConditionMedDRA,
-      primary_sponsor: primarySponsorModel,
-      public_title: publicTitleModel,
-      recruitment: recruitmentModel,
-      scientific_title: scientificTitleModel,
-      secondaries_trial_numbers: secondariesTrialNumbersModel,
-      study_type: studyTypeModel,
-      therapeutic_areas: therapeuticAreas,
-      universal_trial_number: universalTrialNumberModel,
-    })
-    const repository = await createRepository([clinicalTrialModel])
+    const repository = await createRepository([clinicalTrialFileModel as ClinicalTrialModel])
 
     // WHEN
-    const clinicalTrial = repository.findOne('123')
+    const clinicalTrial = repository.findOne('1')
 
     // THEN
     expect(clinicalTrial).toStrictEqual(new ClinicalTrial(
-      'NCT51265816',
-      {
-        AFR_number:  'AFRXXXXXXXX',
-        national_number: '2011-006209-83',
-      },
-      new Title(
-        'AGADIR',
-        'Circuler l’ADN pour améliorer le résultat de l’oncologie Patient. Une étude randomisée'
-      ),
-      new Title(
-        'AGADIR',
-        'le meme titre mais en scientifique'
-      ),
+      '',
+      {},
+      new Title('', ''),
+      new Title('', ''),
       new Recruitment(
-        RecruitmentStatus.RECRUITING,
-        [Gender.MALE],
-        [PrimaryAge.IN_UTERO, PrimaryAge.SIXTY_FIVE_PLUS_YEARS],
-        [SecondaryAge.PRETERM_NEWBORN, SecondaryAge.EIGHTY_FIVE_PLUS_YEARS],
-        400
+        RecruitmentStatus.UNAVAILABLE,
+        [],
+        [],
+        [],
+        0
       ),
       new StudyType(
-        'Human Pharmacology (Phase I)- First administration to humans',
+        '',
         '',
         ''
       ),
-      new Date().toString(),
+      '',
       new Contact(
-        new ContactDetails(
-          'Institut Bergognié',
-          'Antoine',
-          'Italiano',
-          '5 avenue de l’opera',
-          'bordeaux',
-          'France',
-          '33076',
-          '01 23 45 67 89 ',
-          'aitaliona@example',
-          'Ministère de la santé',
-          '552 178 639 00132'
-        ),
-        new ContactDetails(
-          'John Doe',
-          'John',
-          'Doe',
-          '123 rue de la cabosse',
-          'Saint-François-sur-Seine',
-          'France',
-          '01234',
-          '(+33)1 23 45 67 89',
-          'johndoe@ministere.com',
-          'Ministère de la Santé',
-          ''
-        )
+        new ContactDetails('', '', '', '', '', '', '', '', '', '', ''),
+        new ContactDetails('', '', '', '', '', '', '', '', '', '', '')
       ),
-      'Cancer des poumons',
-      ['10060929', '10072818'],
-      [new TherapeuticArea('Circulatory and Respiratory Physiological Phenomena', 'G')],
-      new ContactDetails(
-        'Institut Bergognié',
-        'Antoine',
-        'Italiano',
-        '5 avenue de l’opera',
-        'bordeaux',
-        'France',
-        '33076',
-        '01 23 45 67 89 ',
-        'aitaliona@example',
-        'Ministère de la santé',
-        '552 178 639 00132'
-      )
+      '',
+      [],
+      [],
+      new ContactDetails('', '', '', '', '', '', '', '', '', '', '')
     ))
   })
 

--- a/src/clinical-trial/gateways/file-repository/clinical-trial-file.repository.ts
+++ b/src/clinical-trial/gateways/file-repository/clinical-trial-file.repository.ts
@@ -1,16 +1,8 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 
+import { ClinicalTrialFactory } from './clinical-trial-factory'
 import { ClinicalTrial } from '../../application/entities/ClinicalTrial'
-import { Contact } from '../../application/entities/Contact'
-import { ContactDetails } from '../../application/entities/ContactDetails'
-import { Recruitment } from '../../application/entities/Recruitment'
-import { StudyType } from '../../application/entities/StudyType'
-import { TherapeuticArea } from '../../application/entities/TherapeuticArea'
-import { Title } from '../../application/entities/Title'
-import { Gender } from '../../application/Gender'
 import { ClinicalTrialRepository } from '../../application/interfaces/ClinicalTrialRepository'
-import { PrimaryAge } from '../../application/PrimaryAge'
-import { SecondaryAge } from '../../application/SecondaryAge'
 import { ClinicalTrialModel } from '../model/ClinicalTrialModel'
 
 @Injectable()
@@ -18,104 +10,31 @@ export class ClinicalTrialFileRepository implements ClinicalTrialRepository {
   private readonly clinicalTrialsRepository: ClinicalTrialModel[] = []
 
   constructor(clinicalTrialsModel: ClinicalTrialModel[]) {
-    clinicalTrialsModel.forEach((clinicalTrialModel) => {
+    clinicalTrialsModel.forEach((clinicalTrialFile) => {
       this.clinicalTrialsRepository.push(new ClinicalTrialModel(
-        clinicalTrialModel.uuid,
-        clinicalTrialModel.universal_trial_number,
-        clinicalTrialModel.secondaries_trial_numbers,
-        clinicalTrialModel.public_title,
-        clinicalTrialModel.scientific_title,
-        clinicalTrialModel.recruitment,
-        clinicalTrialModel.study_type,
-        clinicalTrialModel.last_revision_date,
-        clinicalTrialModel.contact,
-        clinicalTrialModel.medical_condition,
-        clinicalTrialModel.medical_condition_meddra,
-        clinicalTrialModel.therapeutic_areas,
-        clinicalTrialModel.primary_sponsor
+        clinicalTrialFile.uuid,
+        clinicalTrialFile.universal_trial_number,
+        clinicalTrialFile.secondaries_trial_numbers,
+        clinicalTrialFile.public_title,
+        clinicalTrialFile.scientific_title,
+        clinicalTrialFile.recruitment,
+        clinicalTrialFile.study_type,
+        clinicalTrialFile.last_revision_date,
+        clinicalTrialFile.contact,
+        clinicalTrialFile.medical_condition,
+        clinicalTrialFile.medical_condition_meddra,
+        clinicalTrialFile.therapeutic_areas,
+        clinicalTrialFile.primary_sponsor
       ))
     })
   }
 
   findOne(uuid: string): ClinicalTrial {
     const clinicalTrialModel = this.clinicalTrialsRepository.find((clinicalTrial) => clinicalTrial.uuid === uuid)
-
     if (!clinicalTrialModel) {
       throw new NotFoundException()
     }
 
-    return this.buildClinicalTrialEntity(clinicalTrialModel)
-  }
-
-  private buildClinicalTrialEntity(clinicalTrialModel: ClinicalTrialModel): ClinicalTrial {
-    return new ClinicalTrial(
-      clinicalTrialModel.universal_trial_number,
-      clinicalTrialModel.secondaries_trial_numbers,
-      new Title(
-        clinicalTrialModel.public_title.acronym,
-        clinicalTrialModel.public_title.value
-      ),
-      new Title(
-        clinicalTrialModel.scientific_title.acronym,
-        clinicalTrialModel.scientific_title.value
-      ),
-      new Recruitment(
-        clinicalTrialModel.recruitment.status,
-        clinicalTrialModel.recruitment.genders.map((gender: string): Gender => Gender[gender as keyof typeof Gender]),
-        clinicalTrialModel.recruitment.ages_range.map((age: string): PrimaryAge => PrimaryAge[age as keyof typeof PrimaryAge]),
-        clinicalTrialModel.recruitment.ages_range_secondary_identifiers.map((age: string): SecondaryAge => SecondaryAge[age as keyof typeof SecondaryAge]),
-        clinicalTrialModel.recruitment.target_number
-      ),
-      new StudyType(
-        clinicalTrialModel.study_type.phase,
-        clinicalTrialModel.study_type.study_type,
-        clinicalTrialModel.study_type.study_design
-      ),
-      clinicalTrialModel.last_revision_date,
-      new Contact(
-        new ContactDetails(
-          clinicalTrialModel.contact.public_queries.name,
-          clinicalTrialModel.contact.public_queries.firstname,
-          clinicalTrialModel.contact.public_queries.lastname,
-          clinicalTrialModel.contact.public_queries.address,
-          clinicalTrialModel.contact.public_queries.city,
-          clinicalTrialModel.contact.public_queries.country,
-          clinicalTrialModel.contact.public_queries.zip,
-          clinicalTrialModel.contact.public_queries.telephone,
-          clinicalTrialModel.contact.public_queries.email,
-          clinicalTrialModel.contact.public_queries.organization,
-          clinicalTrialModel.contact.public_queries.siret
-        ),
-        new ContactDetails(
-          clinicalTrialModel.contact.scientific_queries.name,
-          clinicalTrialModel.contact.scientific_queries.firstname,
-          clinicalTrialModel.contact.scientific_queries.lastname,
-          clinicalTrialModel.contact.scientific_queries.address,
-          clinicalTrialModel.contact.scientific_queries.city,
-          clinicalTrialModel.contact.scientific_queries.country,
-          clinicalTrialModel.contact.scientific_queries.zip,
-          clinicalTrialModel.contact.scientific_queries.telephone,
-          clinicalTrialModel.contact.scientific_queries.email,
-          clinicalTrialModel.contact.scientific_queries.organization,
-          clinicalTrialModel.contact.scientific_queries.siret
-        )
-      ),
-      clinicalTrialModel.medical_condition,
-      clinicalTrialModel.medical_condition_meddra,
-      clinicalTrialModel.therapeutic_areas.map((item) => new TherapeuticArea(item.value, item.code)),
-      new ContactDetails(
-        clinicalTrialModel.primary_sponsor.name,
-        clinicalTrialModel.primary_sponsor.firstname,
-        clinicalTrialModel.primary_sponsor.lastname,
-        clinicalTrialModel.primary_sponsor.address,
-        clinicalTrialModel.primary_sponsor.city,
-        clinicalTrialModel.primary_sponsor.country,
-        clinicalTrialModel.primary_sponsor.zip,
-        clinicalTrialModel.primary_sponsor.telephone,
-        clinicalTrialModel.primary_sponsor.email,
-        clinicalTrialModel.primary_sponsor.organization,
-        clinicalTrialModel.primary_sponsor.siret
-      )
-    )
+    return ClinicalTrialFactory.buildClinicalTrial(clinicalTrialModel)
   }
 }

--- a/src/clinical-trial/gateways/file-repository/clinical-trial-file.repository.ts
+++ b/src/clinical-trial/gateways/file-repository/clinical-trial-file.repository.ts
@@ -35,6 +35,6 @@ export class ClinicalTrialFileRepository implements ClinicalTrialRepository {
       throw new NotFoundException()
     }
 
-    return ClinicalTrialFactory.buildClinicalTrial(clinicalTrialModel)
+    return ClinicalTrialFactory.create(clinicalTrialModel)
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     clearMocks: true,
     coverage: {
-      exclude: ['.stryker-tmp/**/*.ts'],
+      exclude: ['.stryker-tmp/**'],
       provider: 'istanbul',
     },
     environment: 'node',


### PR DESCRIPTION
Refactorisation du repository. 
- On sort le builder dans une factory (ce n'est plus la responsabilité du repo de builder un ClinicalTrial)
- On modifie les tests en conséquences et on décharge le repo de tester les attributs du ClinicalTrial dans le test de la factory

# Vérifier avant de merger

- [x] As tu mis à jour Swagger ?
- [x] As tu mis à jour Postman ?
- [x] As-tu correctement relu ton code ?
- [x] As-tu lancer la CI en local `yarn amibroken`  ?
- [x] As-tu lancer les tests de mutation ?
- [x] As-tu besoin de revoir ton ticket avec le métier ?
- [x] Faut-il ajouter des variables d'environnement sur la production ?
