### PR TITLE
perf: réduction du nombre maximum de documents (1000) en sortie de l'API /R4/ResearchStudy pour tenir des temps de réponse acceptables (< 2 sec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ yarn start:db
 ```bash
 yarn test
 
-yarn test:e2e
-
 yarn test:coverage
 
-yarn test:mutation
+yarn test:mutation:api
+
+yarn test:mutation:etl
 ```
 
 ### Lancer le linter

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "node": "18.16"
   },
-  "packageManager": "yarn@4.7.0",
+  "packageManager": "yarn@4.8.1",
   "scripts": {
     "amibroken": "yarn dedupe --check && yarn typecheck && yarn lint && yarn test",
     "bash:production": "scalingo -a eclaire-api run bash",

--- a/src/api/research-study/controllers/FhirQueryParams.ts
+++ b/src/api/research-study/controllers/FhirQueryParams.ts
@@ -44,10 +44,12 @@ export class FhirQueryParams {
     _content: string
 
   @ApiProperty({
-    description: 'De `1` à `5 000`, valeur par défaut `20` si vide',
+    description: 'De `1` à `1000`, valeur par défaut `20` si vide',
+    maximum: 1000,
+    minimum: 1,
     required: false,
   })
-    _count: string
+    _count: number
 
   _getpagesoffset: string
   search_after: string

--- a/src/api/research-study/gateways/converter/convertFhirParsedQueryParamsToElasticsearchQuery.test.ts
+++ b/src/api/research-study/gateways/converter/convertFhirParsedQueryParamsToElasticsearchQuery.test.ts
@@ -300,9 +300,9 @@ describe('research study query to elasticsearch query', () => {
       })
     })
 
-    it('with a count limit to 5000', () => {
+    it('with a count limit to 1000', () => {
       // GIVEN
-      const numberOfResourcesByPage = 5001
+      const numberOfResourcesByPage = 1001
       const offset = numberOfResourcesByPage * 9
       const researchStudyQuery: FhirParsedQueryParams[] = [
         { name: '_count', value: String(numberOfResourcesByPage) },

--- a/src/api/research-study/gateways/converter/convertFhirParsedQueryParamsToElasticsearchQuery.ts
+++ b/src/api/research-study/gateways/converter/convertFhirParsedQueryParamsToElasticsearchQuery.ts
@@ -99,7 +99,7 @@ function buildFrom(searchBody: ElasticsearchBodyBuilder, value: string) {
 }
 
 function buildSize(searchBody: ElasticsearchBodyBuilder, value: string) {
-  const maxSize = 5_000
+  const maxSize = 1_000
 
   if (Number(value) <= maxSize) {
     searchBody.withSize(Number(value))

--- a/src/shared/elasticsearch/ElasticsearchService.ts
+++ b/src/shared/elasticsearch/ElasticsearchService.ts
@@ -150,7 +150,7 @@ export class ElasticsearchService {
   }
 
   async bulkMedDraDocuments<T>(documents: T[]): Promise<void> {
-    const chunkSize = 5000
+    const chunkSize = 1000
 
     for (let i = 0; i < documents.length; i += chunkSize) {
       const chunk = documents.slice(i, i + chunkSize)


### PR DESCRIPTION
# Vérifier avant de merger

- [x] As tu mis à jour Swagger ?
- [x] As tu [valider](https://validator.fhir.org/) ton implémentation de FHIR ?
- [x] As-tu correctement relu ton code ?
- [x] As-tu lancer les tests de mutation ?
- [x] As-tu besoin de revoir ton ticket avec le métier ?
- [x] Faut-il ajouter des variables d'environnement sur la production ?
